### PR TITLE
Allow to pass in a function to format the label

### DIFF
--- a/src/components/Histoslider.js
+++ b/src/components/Histoslider.js
@@ -121,6 +121,7 @@ Histoslider.propTypes = {
   showOnDrag: PropTypes.bool,
   style: PropTypes.object,
   handleLabelFormat: PropTypes.string,
+  formatLabelFunction: PropTypes.func,
   disableHistogram: PropTypes.bool
 };
 
@@ -134,7 +135,8 @@ Histoslider.defaultProps = {
   barPadding: 3,
   padding: 20,
   sliderHeight: 25,
-  handleLabelFormat: "0.3P"
+  handleLabelFormat: "0.3P",
+  formatLabelFunction: undefined
 };
 
 export default Histoslider;

--- a/src/components/Slider.js
+++ b/src/components/Slider.js
@@ -131,7 +131,8 @@ class Slider extends Component {
     } = this.props;
     const selectionWidth = Math.abs(scale(selection[1]) - scale(selection[0]));
     const selectionSorted = Array.from(selection).sort((a, b) => +a - +b);
-    const f = d3Format(handleLabelFormat);
+    const defaultLabelFormatFunction = d3Format(handleLabelFormat);
+    const f = formatLabelFunction || defaultLabelFormatFunction;
     return (
       <svg
         style={sliderStyle}

--- a/src/components/Slider.js
+++ b/src/components/Slider.js
@@ -119,6 +119,7 @@ class Slider extends Component {
       scale,
       format,
       handleLabelFormat,
+      formatLabelFunction,
       width,
       height,
       reset,
@@ -219,6 +220,7 @@ Slider.propTypes = {
   dragChange: PropTypes.func,
   onChange: PropTypes.func,
   handleLabelFormat: PropTypes.string,
+  formatLabelFunction: PropTypes.func,
   sliderStyle: PropTypes.object,
   showLabels: PropTypes.bool,
   labelStyle: PropTypes.object

--- a/src/stories/index.js
+++ b/src/stories/index.js
@@ -33,6 +33,29 @@ const buckets = [
   }
 ];
 
+const dateTimeData = [
+  {
+    x0: new Date('2020-01-01').valueOf(),
+    x: new Date('2020-01-30').valueOf(),
+    y: 8
+  },
+  {
+    x0: new Date('2020-02-01').valueOf(),
+    x: new Date('2020-02-28').valueOf(),
+    y: 2
+  },
+  {
+    x0: new Date('2020-03-01').valueOf(),
+    x: new Date('2020-03-30').valueOf(),
+    y: 0
+  },
+  {
+    x0: new Date('2020-04-01').valueOf(),
+    x: new Date('2020-04-30').valueOf(),
+    y: 2
+  }
+];
+
 // Stateful container for testing interaction
 class HistosliderContainer extends Component {
   state = {
@@ -71,7 +94,17 @@ storiesOf("Histoslider", module)
       width={800}
     />
   )
-  .add("No labels", () => 
+  .add("No labels", () =>
     <HistosliderContainer
       showLabels={false}/>
-  );
+  ).add("Date time data", () =>
+    <HistosliderContainer
+        data={dateTimeData}
+        formatLabelFunction={(value) => {
+          const date = new Date(value);
+          const dtf = new Intl.DateTimeFormat('en', {year: 'numeric', month: 'short', day: '2-digit'});
+          const [{value: mo}, , {value: da}, , {value: ye}] = dtf.formatToParts(date);
+          return `${da}-${mo}-${ye}`;
+        }}
+    />
+  )

--- a/src/typings/histoslider.d.ts
+++ b/src/typings/histoslider.d.ts
@@ -28,10 +28,11 @@ declare module 'histoslider' {
         showOnDrag?: boolean;
         style?: any;
         handleLabelFormat?: string;
+        formatLabelFunction?: (value: number) => string;
         disableHistogram?: boolean;
         showLabels?: boolean;
     }
 
-    export class Histoslider extends React.Component<HistosliderProps, any> { 
+    export class Histoslider extends React.Component<HistosliderProps, any> {
     }
 }


### PR DESCRIPTION
In our project, we want to use a histogram slider with dates. Unfortunately, as `d3-format` doesn't support date and time, we would need to define a custom way of rendering the labels.
This PR will allow to pass in a function as `formatLabelFunction` which will be used instead of `d3Format(...)` if one is passed in.
I would be open to any kinds of changes, thanks!